### PR TITLE
feat: add issuer as class property

### DIFF
--- a/src/strategy.ts
+++ b/src/strategy.ts
@@ -30,6 +30,7 @@ export type ZitadelIntrospectionOptions = {
   authority: string;
   authorization: EndpointAuthoriztaion;
   discoveryEndpoint?: string;
+  introspectionEndpoint?: string;
   issuer?: Issuer;
 };
 
@@ -37,11 +38,13 @@ export class ZitadelIntrospectionStrategy extends Strategy {
   name = 'zitadel-introspection';
 
   private issuer: Issuer | undefined;
+  private introspectionEndpoint: string;
   private introspect?: (token: string) => Promise<IntrospectionResponse>;
 
   constructor(private readonly options: ZitadelIntrospectionOptions) {
     super();
     this.issuer = options.issuer;
+    this.introspectionEndpoint = options.introspectionEndpoint || '';
   }
 
   public static async create(options: ZitadelIntrospectionOptions): Promise<ZitadelIntrospectionStrategy> {
@@ -84,8 +87,12 @@ export class ZitadelIntrospectionStrategy extends Strategy {
   }
 
   private async getIntrospecter() {
-    if (!this.issuer) this.issuer = await Issuer.discover(this.options.discoveryEndpoint ?? this.options.authority);
-    const introspectionEndpoint = this.issuer.metadata['introspection_endpoint'] as string;
+    if (!this.introspectionEndpoint) {
+      if (!this.issuer) {
+        this.issuer = await Issuer.discover(this.options.discoveryEndpoint ?? this.options.authority);
+      }
+      this.introspectionEndpoint = this.issuer.metadata['introspection_endpoint'] as string;
+    }
 
     let jwt = '';
     let lastCreated = 0;
@@ -125,7 +132,7 @@ export class ZitadelIntrospectionStrategy extends Strategy {
     return async (token: string) => {
       const payload = await getPayload(token);
 
-      const response = await axios.post(introspectionEndpoint, new URLSearchParams(payload), {
+      const response = await axios.post(this.introspectionEndpoint, new URLSearchParams(payload), {
         auth:
           this.options.authorization.type === 'basic'
             ? {


### PR DESCRIPTION
Allow to define issuer once per instance

Fix: https://github.com/buehler/node-passport-zitadel/issues/143